### PR TITLE
Adds support for Guest Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
+api calls requires auhorization header with an JWT token from keycloak
+```curl
+POST https://myapi/action HTTP/1.1
+Auhorization: Bearer JwtTokenContent
+```
+
 If you pass "IConfiguration" instead of "Action\<ApiAuthOptions\>" to "AddKeycloak" add the following to appsettings.json:
 ```js
   "ApiAuthOptions": {
@@ -35,6 +41,7 @@ If you pass "IConfiguration" instead of "Action\<ApiAuthOptions\>" to "AddKeyclo
 
 ### Guest Authentication
 
+add to api
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -43,11 +50,19 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-If you pass "IConfiguration" instead of "Action\<GuestAuthOptions\>" to "AddGuest" you can can setup configuration by appsettings.json:
+api calls requires header guestid with an "Version 4 UUID"
+```curl
+POST https://myapi/action HTTP/1.1
+guestid: 1c11792b-538f-4908-992d-6570bb268e60
+```
+
+If you pass "IConfiguration" instead of "Action\<GuestAuthOptions\>" to "AddGuest" you can can override the default settings in appsettings.json:
 ```js
   "GuestAuthOptions": {
     "Enabled": true,
-    "Role": "SomeGuestRole"
+    "Name": "guest-[GuestID]",    
+    "Role": "SomeGuestRole",
+    "Validator": "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This provides a way to secure your api with keycloak jwt bearer authentication.
 
 ### Keycloak JWT Authentication
 
+Add it to your api.
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -25,7 +26,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-api calls requires auhorization header with an JWT token from keycloak
+Api calls requires auhorization header with an JWT token from keycloak.
 ```curl
 POST https://myapi/action HTTP/1.1
 Auhorization: Bearer JwtTokenContent
@@ -41,7 +42,7 @@ If you pass "IConfiguration" instead of "Action\<ApiAuthOptions\>" to "AddKeyclo
 
 ### Guest Authentication
 
-add to api
+Add it to your api.
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -50,7 +51,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-api calls requires header guestid with an "Version 4 UUID"
+Api calls requires header guestid with an "Version 4 UUID".
 ```curl
 POST https://myapi/action HTTP/1.1
 guestid: 1c11792b-538f-4908-992d-6570bb268e60
@@ -84,11 +85,12 @@ You can setup your supported authentication types on each controller action per 
 [HttpPost]
 [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme + ", " + GuestAuthenticationDefaults.AuthenticationScheme)]
 public async Task<IActionResult> ActionForBoth()
-...
+{}
 
 [HttpPost]
 [Authorize(GuestAuthenticationDefaults.AuthenticationScheme)]
 public async Task<IActionResult> ActionForGuests()
+{}
 ```
 
 
@@ -99,6 +101,6 @@ public async Task<IActionResult> ActionForGuests()
 - set package version in Samhammer.Authentication.Abstractions.csproj
 - create git tag
 - dotnet pack -c Release
-- nuget push .Samhammer.Authentication.Api\bin\Release\Samhammer.Authentication.Api.*.nupkg NUGET_API_KEY -src https://api.nuget.org/v3/index.json
-- nuget push .Samhammer.Authentication.Abstractions\bin\Release\Samhammer.Authentication.Abstractions.*.nupkg NUGET_API_KEY -src https://api.nuget.org/v3/index.json
+- nuget push Samhammer.Authentication.Api\bin\Release\Samhammer.Authentication.Api.*.nupkg NUGET_API_KEY -src https://api.nuget.org/v3/index.json
+- nuget push Samhammer.Authentication.Abstractions\bin\Release\Samhammer.Authentication.Abstractions.*.nupkg NUGET_API_KEY -src https://api.nuget.org/v3/index.json
 - (optional) nuget setapikey NUGET_API_KEY -source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This provides a way to secure your api with keycloak jwt bearer authentication.
 
 #### How to use:
 
+### Keycloak JWT Authentication
+
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -30,6 +32,50 @@ If you pass "IConfiguration" instead of "Action\<ApiAuthOptions\>" to "AddKeyclo
     "ClientId": "<<ClientIdRepresentingYourApp>>"
   }
 ```
+
+### Guest Authentication
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddAuthentication(GuestAuthenticationDefaults.AuthenticationScheme)
+        .AddGuest(Configuration);
+}
+```
+
+If you pass "IConfiguration" instead of "Action\<GuestAuthOptions\>" to "AddGuest" you can can setup configuration by appsettings.json:
+```js
+  "GuestAuthOptions": {
+    "Enabled": true,
+    "Role": "SomeGuestRole"
+  }
+```
+
+### Mixed Authentication
+You can also setup both authentication types. In the example below jwt keycloak will be the default.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddJwtAuthentication()
+        .AddKeycloak(Configuration)
+        .AddGuest(Configuration);
+}
+```
+
+You can setup your supported authentication types on each controller action per attribute.
+
+```csharp
+[HttpPost]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme + ", " + GuestAuthenticationDefaults.AuthenticationScheme)]
+public async Task<IActionResult> ActionForBoth()
+...
+
+[HttpPost]
+[Authorize(GuestAuthenticationDefaults.AuthenticationScheme)]
+public async Task<IActionResult> ActionForGuests()
+```
+
 
 ## Contribute
 

--- a/src/Samhammer.Authentication.Api/Guest/AuthenticationBuilderExtensions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/AuthenticationBuilderExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
+
+namespace Samhammer.Authentication.Api.Guest
+{
+    public static class AuthenticationBuilderExtensions
+    {
+        public static AuthenticationBuilder AddGuest(this AuthenticationBuilder builder)
+        {
+            builder.AddGuest(_ => { });
+            return builder;
+        }
+
+        public static AuthenticationBuilder AddGuest(this AuthenticationBuilder builder, Action<GuestAuthOptions> configureOptions)
+        {
+            builder.AddGuest(GuestAuthenticationDefaults.AuthenticationScheme, configureOptions);
+            return builder;
+        }
+
+        public static AuthenticationBuilder AddGuest(this AuthenticationBuilder builder, string scheme, Action<GuestAuthOptions> configureOptions)
+        {
+            builder.AddScheme<GuestAuthOptions, GuestAuthenticationHandler>(scheme, configureOptions);
+            return builder;
+        }
+
+        public static AuthenticationBuilder AddGuest(this AuthenticationBuilder builder, IConfiguration configuration)
+        {
+            builder.AddGuest(GuestAuthenticationDefaults.AuthenticationScheme, configuration);
+            return builder;
+        }
+
+        public static AuthenticationBuilder AddGuest(this AuthenticationBuilder builder, string scheme, IConfiguration configuration)
+        {
+            builder.AddGuest(scheme, options =>
+            {
+                var section = configuration.GetSection(nameof(GuestAuthOptions));
+                section.Bind(options);
+            });
+            return builder;
+        }
+    }
+}

--- a/src/Samhammer.Authentication.Api/Guest/ClaimsPrincipalExtensions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Security.Claims;
+
+namespace Samhammer.Authentication.Api.Guest
+{
+    public static class ClaimsPrincipalExtensions
+    {
+        public static bool IsGuest(this ClaimsPrincipal user)
+        {
+            return string.Equals(user.Identity.AuthenticationType, GuestAuthenticationDefaults.AuthenticationScheme);
+        }
+
+        public static string GetGuestKey(this ClaimsPrincipal user)
+        {
+            return user.HasClaim(c => c.Type == GuestAuthenticationDefaults.ClaimKey)
+                ? user.FindFirst(GuestAuthenticationDefaults.ClaimKey).Value
+                : null;
+        }
+    }
+}

--- a/src/Samhammer.Authentication.Api/Guest/ClaimsPrincipalExtensions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/ClaimsPrincipalExtensions.cs
@@ -9,7 +9,7 @@ namespace Samhammer.Authentication.Api.Guest
             return string.Equals(user.Identity.AuthenticationType, GuestAuthenticationDefaults.AuthenticationScheme);
         }
 
-        public static string GetGuestKey(this ClaimsPrincipal user)
+        public static string GetGuestID(this ClaimsPrincipal user)
         {
             return user.HasClaim(c => c.Type == GuestAuthenticationDefaults.ClaimKey)
                 ? user.FindFirst(GuestAuthenticationDefaults.ClaimKey).Value

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
@@ -10,10 +10,12 @@ namespace Samhammer.Authentication.Api.Guest
 
         public string Role { get; set; }
 
+        public string Validator { get; set; }
+
         public GuestAuthOptions()
         {
-            // set default values
             Name = $"guest-{GuestAuthenticationDefaults.Placeholder}";
+            Validator = "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}"; // uuid v4
             Enabled = true;
         }
     }

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
@@ -4,10 +4,17 @@ namespace Samhammer.Authentication.Api.Guest
 {
     public class GuestAuthOptions : AuthenticationSchemeOptions
     {
-        public bool Enabled { get; set; } = true;
+        public bool Enabled { get; set; }
 
         public string Name { get; set; }
 
         public string Role { get; set; }
+
+        public GuestAuthOptions()
+        {
+            // set default values
+            Name = $"guest-{GuestAuthenticationDefaults.Placeholder}";
+            Enabled = true;
+        }
     }
 }

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthOptions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Authentication;
+
+namespace Samhammer.Authentication.Api.Guest
+{
+    public class GuestAuthOptions : AuthenticationSchemeOptions
+    {
+        public bool Enabled { get; set; } = true;
+
+        public string Name { get; set; }
+
+        public string Role { get; set; }
+    }
+}

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationDefaults.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationDefaults.cs
@@ -3,7 +3,8 @@
     public static class GuestAuthenticationDefaults
     {
         public const string AuthenticationScheme = "Guest";
-        public const string HeaderKey = "X-GuestSession";
-        public const string ClaimKey = "GuestSession";
+        public const string HeaderKey = "GuestID";
+        public const string ClaimKey = "GuestID";
+        public const string Placeholder = "[GuestID]";
     }
 }

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationDefaults.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationDefaults.cs
@@ -1,0 +1,9 @@
+﻿namespace Samhammer.Authentication.Api.Guest
+{
+    public static class GuestAuthenticationDefaults
+    {
+        public const string AuthenticationScheme = "Guest";
+        public const string HeaderKey = "X-GuestSession";
+        public const string ClaimKey = "GuestSession";
+    }
+}

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
@@ -32,7 +32,7 @@ namespace Samhammer.Authentication.Api.Guest
                     return Task.FromResult(AuthenticateResult.NoResult());
                 }
 
-                var guestId = GetGuestId();
+                var guestId = Context.Request.Headers[GuestAuthenticationDefaults.HeaderKey];
 
                 if (!IsAuthorized(guestId))
                 {
@@ -80,11 +80,6 @@ namespace Samhammer.Authentication.Api.Guest
             }
 
             return claims;
-        }
-
-        private string GetGuestId()
-        {
-            return Context.Request.Headers.SingleOrDefault(h => h.Key.Equals(GuestAuthenticationDefaults.HeaderKey)).Value;
         }
     }
 }

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
@@ -33,7 +33,7 @@ namespace Samhammer.Authentication.Api.Guest
 
                 if (!IsAuthorized())
                 {
-                    return Task.FromResult(AuthenticateResult.Fail("UserSession authentication failed"));
+                    return Task.FromResult(AuthenticateResult.Fail("Guest authentication failed"));
                 }
 
                 var claims = CreateClaims();
@@ -45,28 +45,25 @@ namespace Samhammer.Authentication.Api.Guest
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "UserSession authentication error");
-                return Task.FromResult(AuthenticateResult.Fail("UserSession authentication error"));
+                Logger.LogError(ex, "Guest authentication error");
+                return Task.FromResult(AuthenticateResult.Fail("Guest authentication error"));
             }
         }
 
         private bool IsAuthorized()
         {
-            var sessionId = GetSessionId();
+            var sessionId = GetGuestId();
             return !string.IsNullOrEmpty(sessionId);
         }
 
         private List<Claim> CreateClaims()
         {
-            var sessionId = GetSessionId();
+            var guestId = GetGuestId();
+            var name = Options.Name.Replace(GuestAuthenticationDefaults.Placeholder, guestId, StringComparison.OrdinalIgnoreCase);
+
             var claims = new List<Claim>();
-
-            claims.Add(new Claim(GuestAuthenticationDefaults.ClaimKey, sessionId));
-
-            if (!string.IsNullOrEmpty(Options.Name))
-            {
-                claims.Add(new Claim(ClaimTypes.Name, Options.Name));
-            }
+            claims.Add(new Claim(ClaimTypes.Name, name));
+            claims.Add(new Claim(GuestAuthenticationDefaults.ClaimKey, guestId));
 
             if (!string.IsNullOrEmpty(Options.Role))
             {
@@ -76,7 +73,7 @@ namespace Samhammer.Authentication.Api.Guest
             return claims;
         }
 
-        private string GetSessionId()
+        private string GetGuestId()
         {
             return Context.Request.Headers.SingleOrDefault(h => h.Key.Equals(GuestAuthenticationDefaults.HeaderKey)).Value;
         }

--- a/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
+++ b/src/Samhammer.Authentication.Api/Guest/GuestAuthenticationHandler.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Samhammer.Authentication.Api.Guest
+{
+    public class GuestAuthenticationHandler : AuthenticationHandler<GuestAuthOptions>
+    {
+        public GuestAuthenticationHandler(IOptionsMonitor<GuestAuthOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            try
+            {
+                if (!Options.Enabled)
+                {
+                    return Task.FromResult(AuthenticateResult.NoResult());
+                }
+
+                if (!Context.Request.Headers.ContainsKey(GuestAuthenticationDefaults.HeaderKey))
+                {
+                    return Task.FromResult(AuthenticateResult.NoResult());
+                }
+
+                if (!IsAuthorized())
+                {
+                    return Task.FromResult(AuthenticateResult.Fail("UserSession authentication failed"));
+                }
+
+                var claims = CreateClaims();
+                var identity = new ClaimsIdentity(claims, Scheme.Name);
+                var principal = new ClaimsPrincipal(identity);
+                var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+                return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "UserSession authentication error");
+                return Task.FromResult(AuthenticateResult.Fail("UserSession authentication error"));
+            }
+        }
+
+        private bool IsAuthorized()
+        {
+            var sessionId = GetSessionId();
+            return !string.IsNullOrEmpty(sessionId);
+        }
+
+        private List<Claim> CreateClaims()
+        {
+            var sessionId = GetSessionId();
+            var claims = new List<Claim>();
+
+            claims.Add(new Claim(GuestAuthenticationDefaults.ClaimKey, sessionId));
+
+            if (!string.IsNullOrEmpty(Options.Name))
+            {
+                claims.Add(new Claim(ClaimTypes.Name, Options.Name));
+            }
+
+            if (!string.IsNullOrEmpty(Options.Role))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, Options.Role));
+            }
+
+            return claims;
+        }
+
+        private string GetSessionId()
+        {
+            return Context.Request.Headers.SingleOrDefault(h => h.Key.Equals(GuestAuthenticationDefaults.HeaderKey)).Value;
+        }
+    }
+}

--- a/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
+++ b/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
@@ -10,15 +9,12 @@
     <Authors>Samhammer AG</Authors>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
-
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
@@ -26,9 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\Samhammer.Authentication.Abstractions\Samhammer.Authentication.Abstractions.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
+++ b/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Samhammer AG</Company>
     <Authors>Samhammer AG</Authors>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />

--- a/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
+++ b/src/Samhammer.Authentication.Api/Samhammer.Authentication.Api.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Samhammer AG</Company>
     <Authors>Samhammer AG</Authors>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />

--- a/src/Samhammer.Authentication.Example/Controllers/TestController.cs
+++ b/src/Samhammer.Authentication.Example/Controllers/TestController.cs
@@ -1,17 +1,58 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Samhammer.Authentication.Api.Guest;
 
 namespace Samhammer.Authentication.Example.Controllers
 {
     [ApiController]
-    [Authorize]
     [Route("api/[controller]")]
     public class TestController : ControllerBase
     {
-        [HttpGet]
+        [Authorize(AuthenticationSchemes = GuestAuthenticationDefaults.AuthenticationScheme + ", " + JwtBearerDefaults.AuthenticationScheme, Roles = "default")]
+        [HttpGet("both")]
         public string Get()
         {
-            return "Hello World";
+            return $"Welcome {User.Identity.Name}!";
+        }
+
+        [Authorize(Roles = "default")]
+        [HttpGet("unspecific")]
+        public string GetUnspecified()
+        {
+            return $"Welcome {User.Identity.Name}!";
+        }
+
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Roles = "default")]
+        [HttpGet("keyCloakOnly")]
+        public string GetKeyCloak()
+        {
+            return $"Welcome {User.Identity.Name}!";
+        }
+
+        [Authorize(AuthenticationSchemes = GuestAuthenticationDefaults.AuthenticationScheme, Roles = "default")]
+        [HttpGet("userSessionOnly")]
+        public string GetUserSession()
+        {
+            return $"Welcome {User.Identity.Name}!";
+        }
+
+
+        [Authorize(AuthenticationSchemes = GuestAuthenticationDefaults.AuthenticationScheme + ", " + JwtBearerDefaults.AuthenticationScheme)]
+        [HttpGet("userInfo")]
+        public ActionResult<object> GetUserInfo()
+        {
+            return new
+            {
+                loginName = User.Identity.Name,
+                isGuest = User.IsGuest(),
+                guestKey = User.GetGuestKey(),
+                firstName = User.FindFirst(ClaimTypes.GivenName)?.Value,
+                roles = string.Join(", ", User.FindAll(ClaimTypes.Role).Select(c => c.Value)),
+                lastName = User.FindFirst(ClaimTypes.Surname)?.Value
+            };
         }
     }
 }

--- a/src/Samhammer.Authentication.Example/Controllers/TestController.cs
+++ b/src/Samhammer.Authentication.Example/Controllers/TestController.cs
@@ -48,10 +48,10 @@ namespace Samhammer.Authentication.Example.Controllers
             {
                 loginName = User.Identity.Name,
                 isGuest = User.IsGuest(),
-                guestKey = User.GetGuestKey(),
+                guestID = User.GetGuestID(),
                 firstName = User.FindFirst(ClaimTypes.GivenName)?.Value,
-                roles = string.Join(", ", User.FindAll(ClaimTypes.Role).Select(c => c.Value)),
-                lastName = User.FindFirst(ClaimTypes.Surname)?.Value
+                lastName = User.FindFirst(ClaimTypes.Surname)?.Value,
+                roles = string.Join(", ", User.FindAll(ClaimTypes.Role).Select(c => c.Value))
             };
         }
     }

--- a/src/Samhammer.Authentication.Example/Controllers/TestController.cs
+++ b/src/Samhammer.Authentication.Example/Controllers/TestController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Samhammer.Authentication.Example.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/[controller]")]
+    public class TestController : ControllerBase
+    {
+        [HttpGet]
+        public string Get()
+        {
+            return "Hello World";
+        }
+    }
+}

--- a/src/Samhammer.Authentication.Example/Program.cs
+++ b/src/Samhammer.Authentication.Example/Program.cs
@@ -1,0 +1,25 @@
+﻿using ConfigurationSubstitution;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Samhammer.Authentication.Example
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(builder =>
+                {
+                    builder.EnableSubstitutions();
+                })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/Samhammer.Authentication.Example/Samhammer.Authentication.Example.csproj
+++ b/src/Samhammer.Authentication.Example/Samhammer.Authentication.Example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigurationSubstitutor" Version="1.0.2" />
-    <PackageReference Include="Samhammer.Swagger.Authentication" Version="1.0.2" />
+    <PackageReference Include="Samhammer.Swagger.Authentication" Version="1.1.0" />
     <PackageReference Include="Samhammer.Swagger.Default" Version="1.0.2" />
   </ItemGroup>
 

--- a/src/Samhammer.Authentication.Example/Samhammer.Authentication.Example.csproj
+++ b/src/Samhammer.Authentication.Example/Samhammer.Authentication.Example.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>3f13474d-7a41-4212-8660-2ebf263a6c71</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ConfigurationSubstitutor" Version="1.0.2" />
+    <PackageReference Include="Samhammer.Swagger.Authentication" Version="1.0.2" />
+    <PackageReference Include="Samhammer.Swagger.Default" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Samhammer.Authentication.Api\Samhammer.Authentication.Api.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/Samhammer.Authentication.Example/Startup.cs
+++ b/src/Samhammer.Authentication.Example/Startup.cs
@@ -3,14 +3,11 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
 using Samhammer.Authentication.Api.Guest;
 using Samhammer.Authentication.Api.Jwt;
 using Samhammer.Authentication.Api.Keycloak;
 using Samhammer.Swagger.Authentication;
 using Samhammer.Swagger.Default;
-using Swashbuckle.AspNetCore.Filters;
-using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Samhammer.Authentication.Example
 {
@@ -35,29 +32,7 @@ namespace Samhammer.Authentication.Example
             services.AddSwaggerGen();
             services.AddSwaggerDefaultApi();
             services.AddSwaggerAuthentication(Configuration);
-            
-            // TODO move this to Samhammer.Swagger.Authentication
-            services.Configure<SwaggerGenOptions>(c =>
-            {
-                var apiKeyRef = new OpenApiReference
-                {
-                    Id = GuestAuthenticationDefaults.AuthenticationScheme,
-                    Type = ReferenceType.SecurityScheme
-                };
-
-                var apiKeyScheme = new OpenApiSecurityScheme
-                {
-                    Reference = apiKeyRef,
-                    Type = SecuritySchemeType.ApiKey,
-                    In = ParameterLocation.Header,
-                    Name = GuestAuthenticationDefaults.HeaderKey
-                };
-
-                c.AddSecurityDefinition(apiKeyRef.Id, apiKeyScheme);
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement { { apiKeyScheme, new string[] {} } });
-
-                c.OperationFilter<SecurityRequirementsOperationFilter>(true, apiKeyScheme.Reference.Id);
-            });
+            services.AddSwaggerGuest(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Samhammer.Authentication.Example/Startup.cs
+++ b/src/Samhammer.Authentication.Example/Startup.cs
@@ -3,10 +3,14 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using Samhammer.Authentication.Api.Guest;
 using Samhammer.Authentication.Api.Jwt;
 using Samhammer.Authentication.Api.Keycloak;
 using Samhammer.Swagger.Authentication;
 using Samhammer.Swagger.Default;
+using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Samhammer.Authentication.Example
 {
@@ -25,11 +29,35 @@ namespace Samhammer.Authentication.Example
             services.AddControllers();
 
             services.AddJwtAuthentication()
-                .AddKeycloak(Configuration);
+                .AddKeycloak(Configuration)
+                .AddGuest(Configuration);
 
             services.AddSwaggerGen();
             services.AddSwaggerDefaultApi();
             services.AddSwaggerAuthentication(Configuration);
+            
+            // TODO move this to Samhammer.Swagger.Authentication
+            services.Configure<SwaggerGenOptions>(c =>
+            {
+                var apiKeyRef = new OpenApiReference
+                {
+                    Id = GuestAuthenticationDefaults.AuthenticationScheme,
+                    Type = ReferenceType.SecurityScheme
+                };
+
+                var apiKeyScheme = new OpenApiSecurityScheme
+                {
+                    Reference = apiKeyRef,
+                    Type = SecuritySchemeType.ApiKey,
+                    In = ParameterLocation.Header,
+                    Name = GuestAuthenticationDefaults.HeaderKey
+                };
+
+                c.AddSecurityDefinition(apiKeyRef.Id, apiKeyScheme);
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement { { apiKeyScheme, new string[] {} } });
+
+                c.OperationFilter<SecurityRequirementsOperationFilter>(true, apiKeyScheme.Reference.Id);
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Samhammer.Authentication.Example/Startup.cs
+++ b/src/Samhammer.Authentication.Example/Startup.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Samhammer.Authentication.Api.Jwt;
+using Samhammer.Authentication.Api.Keycloak;
+using Samhammer.Swagger.Authentication;
+using Samhammer.Swagger.Default;
+
+namespace Samhammer.Authentication.Example
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddJwtAuthentication()
+                .AddKeycloak(Configuration);
+
+            services.AddSwaggerGen();
+            services.AddSwaggerDefaultApi();
+            services.AddSwaggerAuthentication(Configuration);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseSwagger();
+            app.UseSwaggerUI();
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/src/Samhammer.Authentication.Example/appsettings.json
+++ b/src/Samhammer.Authentication.Example/appsettings.json
@@ -13,7 +13,6 @@
   },
   "GuestAuthOptions": {
     "Enabled": true,
-    "Name": "Guest",
     "Role": "default"
   },
   "SwaggerAuthOptions": {

--- a/src/Samhammer.Authentication.Example/appsettings.json
+++ b/src/Samhammer.Authentication.Example/appsettings.json
@@ -1,0 +1,20 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "KeyCloakRealmUrl": "<FROM_USER_SECRETS>",
+  "ApiAuthOptions": {
+    "Issuer": "{KeyCloakRealmUrl}",
+    "ClientId": "samhammer-authentication-example"
+  },
+  "SwaggerAuthOptions": {
+    "AccessTokenUrl": "{KeyCloakRealmUrl}/protocol/openid-connect/token",
+    "AuthUrl": "{KeyCloakRealmUrl}/protocol/openid-connect/auth",
+    "ClientId": "samhammer-authentication-example-swagger"
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Samhammer.Authentication.Example/appsettings.json
+++ b/src/Samhammer.Authentication.Example/appsettings.json
@@ -11,6 +11,11 @@
     "Issuer": "{KeyCloakRealmUrl}",
     "ClientId": "samhammer-authentication-example"
   },
+  "GuestAuthOptions": {
+    "Enabled": true,
+    "Name": "Guest",
+    "Role": "default"
+  },
   "SwaggerAuthOptions": {
     "AccessTokenUrl": "{KeyCloakRealmUrl}/protocol/openid-connect/token",
     "AuthUrl": "{KeyCloakRealmUrl}/protocol/openid-connect/auth",

--- a/src/Samhammer.Authentication.sln
+++ b/src/Samhammer.Authentication.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samhammer.Authentication.Abstractions", "Samhammer.Authentication.Abstractions\Samhammer.Authentication.Abstractions.csproj", "{33655944-33B4-4033-A4B9-3017D080CE18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samhammer.Authentication.Example", "Samhammer.Authentication.Example\Samhammer.Authentication.Example.csproj", "{D45A627C-EE76-4719-B9F6-E591F9FF18BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{33655944-33B4-4033-A4B9-3017D080CE18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33655944-33B4-4033-A4B9-3017D080CE18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33655944-33B4-4033-A4B9-3017D080CE18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D45A627C-EE76-4719-B9F6-E591F9FF18BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D45A627C-EE76-4719-B9F6-E591F9FF18BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D45A627C-EE76-4719-B9F6-E591F9FF18BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D45A627C-EE76-4719-B9F6-E591F9FF18BB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds authentication support for guests. This can be used instead of anonymous authentication, when the user should be identified over multiple requests (user needs to use a sessionid in the header).
There is no authentication data stored in the user sessionid, instead the users can get a static configured role by configuration.